### PR TITLE
fix(pool): transaction timestamp validation is too restrictive

### DIFF
--- a/src/node/main.go
+++ b/src/node/main.go
@@ -41,7 +41,7 @@ func main() {
 		logger.Fatal(fmt.Errorf("failed to create synchronizer: %w", err).Error())
 	}
 	blockchain := protocol.NewBlockchain(registry, validationTimer, watch, synchronizer, logger)
-	pool := protocol.NewTransactionsPool(registry, watch, logger)
+	pool := protocol.NewTransactionsPool(registry, validationTimer, watch, logger)
 	validation := protocol.NewValidation(wallet.Address(), blockchain, pool, watch, validationTimer, logger)
 	serverFactory := p2p.NewServerFactory()
 	server, err := serverFactory.CreateServer(int(*port))

--- a/src/node/protocol/transactions_pool.go
+++ b/src/node/protocol/transactions_pool.go
@@ -9,6 +9,7 @@ import (
 	"github.com/my-cloud/ruthenium/src/node/network"
 	"math/rand"
 	"sync"
+	"time"
 )
 
 type TransactionsPool struct {
@@ -18,15 +19,17 @@ type TransactionsPool struct {
 
 	registry Registry
 
-	time clock.Time
+	validationTimer time.Duration
+	time            clock.Time
 
 	waitGroup *sync.WaitGroup
 	logger    *log.Logger
 }
 
-func NewTransactionsPool(registry Registry, time clock.Time, logger *log.Logger) *TransactionsPool {
+func NewTransactionsPool(registry Registry, validationTimer time.Duration, time clock.Time, logger *log.Logger) *TransactionsPool {
 	pool := new(TransactionsPool)
 	pool.registry = registry
+	pool.validationTimer = validationTimer
 	pool.time = time
 	var waitGroup sync.WaitGroup
 	pool.waitGroup = &waitGroup
@@ -57,14 +60,17 @@ func (pool *TransactionsPool) addTransaction(transactionRequest *neighborhood.Tr
 		err = fmt.Errorf("failed to instantiate transaction: %w", err)
 		return
 	}
-	if transaction.Timestamp() > pool.time.Now().UnixNano() {
-		err = errors.New("the transaction timestamp is invalid")
-		return
-	}
 	blocks := blockchain.Blocks()
 	if len(blocks) > 1 {
-		if transaction.Timestamp() < blocks[len(blocks)-2].Timestamp {
-			err = errors.New("the transaction timestamp is invalid")
+		timestamp := transaction.Timestamp()
+		nextBlockTimestamp := blocks[len(blocks)-1].Timestamp + 2*pool.validationTimer.Nanoseconds()
+		if nextBlockTimestamp < timestamp {
+			err = fmt.Errorf("the transaction timestamp is too far in the future: %v, now: %v", time.Unix(0, timestamp), time.Unix(0, nextBlockTimestamp))
+			return
+		}
+		previousBlockTimestamp := blocks[len(blocks)-2].Timestamp
+		if timestamp < previousBlockTimestamp {
+			err = fmt.Errorf("the transaction timestamp is too old: %v, previous block timestamp: %v", time.Unix(0, timestamp), time.Unix(0, previousBlockTimestamp))
 			return
 		}
 		for i := len(blocks) - 2; i < len(blocks); i++ {
@@ -119,14 +125,14 @@ func (pool *TransactionsPool) Validate(timestamp int64, blockchain *Blockchain, 
 	var reward uint64
 	var rejectedTransactions []*Transaction
 	for _, transaction := range transactions {
-		if transaction.Timestamp() > timestamp {
-			pool.logger.Warn(fmt.Sprintf("transaction removed from the transactions pool, the transaction timestamp is invalid, transaction: %v", transaction))
+		if timestamp+pool.validationTimer.Nanoseconds() < transaction.Timestamp() {
+			pool.logger.Warn(fmt.Sprintf("transaction removed from the transactions pool, the transaction timestamp is too far in the future, transaction: %v", transaction))
 			rejectedTransactions = append(rejectedTransactions, transaction)
 			continue
 		}
 		if len(blocks) > 1 {
 			if transaction.Timestamp() < blocks[len(blocks)-2].Timestamp {
-				pool.logger.Warn(fmt.Sprintf("transaction removed from the transactions pool, the transaction timestamp is invalid, transaction: %v", transaction))
+				pool.logger.Warn(fmt.Sprintf("transaction removed from the transactions pool, the transaction timestamp is too old, transaction: %v", transaction))
 				rejectedTransactions = append(rejectedTransactions, transaction)
 				continue
 			}


### PR DESCRIPTION
# Checklist:
- [ ] The code follows the [our conventions](https://github.com/my-cloud/ruthenium/blob/main/CONTRIBUTING.md#go).
- [ ] Important principle changes have been documented in the [wiki](https://github.com/my-cloud/ruthenium/wiki).
- [ ] The new code is covered by unit tests with assertions.
- [ ] The behaviour have been manually [tested](https://github.com/my-cloud/ruthenium/wiki/Usage) and is as expected.
- [ ] The target branch is `main`.
- [ ] The commit will be squashed.
- [ ] The squash commit message follows [our conventions](https://github.com/my-cloud/ruthenium/blob/main/CONTRIBUTING.md#git).
- [ ] The branch will be deleted after being merged.
