### PR TITLE
Fix node readme misleading information

### DIFF
--- a/src/node/README.md
+++ b/src/node/README.md
@@ -2,7 +2,7 @@
 In this repository, the host node is an implementation following the Ruthenium protocol. Any other implementation can contribute to run the network if it exposes the same [API](#api) and follows the protocol described in the Ruthenium [whitepaper](https://github.com/my-cloud/ruthenium/wiki/Whitepaper).
 
 ## Prerequisites
-* A DNS port must be open. The port number will be the value of the `port` [program argument](#program-arguments).
+* A firewall port must be open. The port number will be the value of the `port` [program argument](#program-arguments).
 * If you want to [validate](https://github.com/my-cloud/ruthenium/wiki/Whitepaper#validation) [blocks](https://github.com/my-cloud/ruthenium/wiki/Whitepaper#block) or get an [income](https://github.com/my-cloud/ruthenium/wiki/Whitepaper#income), you must be registered in the [Proof of Humanity](https://github.com/my-cloud/ruthenium/wiki/Whitepaper#proof-of-humanity) registry with an Ethereum wallet address for which you are the owner of the private key.
 
 ## Launch


### PR DESCRIPTION
Precise that a firewall port must be opened, which has nothing to do with DNS.

# Checklist:
- [ ] The code follows our code [conventions](https://github.com/my-cloud/ruthenium/blob/main/.github/CONTRIBUTING.md#go).
- [ ] Important principle changes have been documented in the [wiki](https://github.com/my-cloud/ruthenium/wiki).
- [ ] The new code is covered by unit tests with assertions.
- [ ] The behaviour [node](https://github.com/my-cloud/ruthenium/blob/main/src/node) and [UI](https://github.com/my-cloud/ruthenium/blob/main/src/ui) have been manually tested and is as expected.
- [ ] The squash commit message follows our [conventions](https://github.com/my-cloud/ruthenium/blob/main/.github/CONTRIBUTING.md#git).
